### PR TITLE
Phrase API - controller service module 개발 

### DIFF
--- a/db/migrations/1676976004987-phrase-entity-update.ts
+++ b/db/migrations/1676976004987-phrase-entity-update.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class phraseEntityUpdate1676976004987 implements MigrationInterface {
+    name = 'phraseEntityUpdate1676976004987'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "phrase" DROP COLUMN "createAt"`);
+        await queryRunner.query(`ALTER TABLE "phrase" ADD "createAt" TIMESTAMP NOT NULL DEFAULT now()`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "phrase" DROP COLUMN "createAt"`);
+        await queryRunner.query(`ALTER TABLE "phrase" ADD "createAt" TIMESTAMP WITH TIME ZONE NOT NULL`);
+    }
+
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { BooksModule } from './books/books.module';
 import { dataSoureOptions } from '../db/data-source';
 import { UsersModule } from './users/users.module';
+import { PhraseModule } from './phrase/phrase.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(dataSoureOptions), BooksModule, UsersModule],
+  imports: [TypeOrmModule.forRoot(dataSoureOptions), BooksModule, UsersModule, PhraseModule],
   controllers: [],
   providers: [],
 })

--- a/src/books/books.module.ts
+++ b/src/books/books.module.ts
@@ -8,5 +8,6 @@ import { Book } from './entity/book.entity';
   imports: [TypeOrmModule.forFeature([Book])],
   controllers: [BooksController],
   providers: [BooksService],
+  exports: [BooksService],
 })
 export class BooksModule {}

--- a/src/books/entity/book.entity.ts
+++ b/src/books/entity/book.entity.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { Phrase } from './phrase.entity';
+import { Phrase } from '../../phrase/entity/phrase.entity';
 
 @Entity()
 export class Book {

--- a/src/curations/entity/curation.entity.ts
+++ b/src/curations/entity/curation.entity.ts
@@ -26,4 +26,5 @@ export class Curation {
     inverseJoinColumn: { name: 'bookId' },
   })
   books: Book[];
+  ph;
 }

--- a/src/curations/entity/curation.entity.ts
+++ b/src/curations/entity/curation.entity.ts
@@ -26,5 +26,4 @@ export class Curation {
     inverseJoinColumn: { name: 'bookId' },
   })
   books: Book[];
-  ph;
 }

--- a/src/phrase/dto/create-phrase.dto.ts
+++ b/src/phrase/dto/create-phrase.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class CreatePhraseDto {
+  @IsNotEmpty()
+  @IsNumber()
+  bookId: number;
+
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+}

--- a/src/phrase/dto/update-phrase.dto.ts
+++ b/src/phrase/dto/update-phrase.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class UpdatePhraseDto {
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+}

--- a/src/phrase/entity/phrase.entity.ts
+++ b/src/phrase/entity/phrase.entity.ts
@@ -1,5 +1,5 @@
 import { User } from '../../users/entity/user.entity';
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Book } from '../../books/entity/book.entity';
 
 @Entity()
@@ -13,9 +13,11 @@ export class Phrase {
   @CreateDateColumn()
   createAt: Date;
 
-  @ManyToOne(() => Book, book => book.phrases)
+  @ManyToOne(() => Book, book => book.phrases, { eager: true })
+  @JoinColumn()
   book: Book;
 
-  @ManyToOne(() => User, user => user.phrases)
+  @ManyToOne(() => User, user => user.phrases, { eager: true })
+  @JoinColumn()
   user: User;
 }

--- a/src/phrase/entity/phrase.entity.ts
+++ b/src/phrase/entity/phrase.entity.ts
@@ -1,6 +1,6 @@
 import { User } from '../../users/entity/user.entity';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { Book } from './book.entity';
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Book } from '../../books/entity/book.entity';
 
 @Entity()
 export class Phrase {
@@ -10,7 +10,7 @@ export class Phrase {
   @Column()
   content: string;
 
-  @Column({ type: 'timestamptz' })
+  @CreateDateColumn()
   createAt: Date;
 
   @ManyToOne(() => Book, book => book.phrases)

--- a/src/phrase/phrase.controller.spec.ts
+++ b/src/phrase/phrase.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PhraseController } from './phrase.controller';
+
+describe('PhraseController', () => {
+  let controller: PhraseController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PhraseController],
+    }).compile();
+
+    controller = module.get<PhraseController>(PhraseController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/phrase/phrase.controller.ts
+++ b/src/phrase/phrase.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { CreatePhraseDto } from './dto/create-phrase.dto';
+import { PhraseService } from './phrase.service';
+
+@Controller('phrase')
+export class PhraseController {
+  constructor(private readonly phraseService: PhraseService) {}
+
+  @Post()
+  create(@Body() createPhraseDto: CreatePhraseDto) {
+    return this.phraseService.create(createPhraseDto);
+  }
+}

--- a/src/phrase/phrase.controller.ts
+++ b/src/phrase/phrase.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, Delete } from '@nestjs/common';
 import { CreatePhraseDto } from './dto/create-phrase.dto';
+import { UpdatePhraseDto } from './dto/update-phrase.dto';
 import { PhraseService } from './phrase.service';
 
 @Controller('phrase')
@@ -9,5 +10,25 @@ export class PhraseController {
   @Post()
   create(@Body() createPhraseDto: CreatePhraseDto) {
     return this.phraseService.create(createPhraseDto);
+  }
+
+  @Get('recommend')
+  recommendPhrase(@Query('count') count: number) {
+    return this.phraseService.recommendPhrase(count);
+  }
+
+  @Get()
+  getPhrase(@Query('bookId') bookId: number) {
+    return this.phraseService.getPhrase(bookId);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: number, @Body() updatePhraseDto: UpdatePhraseDto) {
+    return this.phraseService.update(id, updatePhraseDto);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: number, @Body('userId') userId: string) {
+    return this.phraseService.delete(id, userId);
   }
 }

--- a/src/phrase/phrase.module.ts
+++ b/src/phrase/phrase.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BooksModule } from '../books/books.module';
+import { Phrase } from './entity/phrase.entity';
+import { PhraseController } from './phrase.controller';
+import { PhraseService } from './phrase.service';
+import { UsersModule } from 'src/users/users.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Phrase]), BooksModule, UsersModule],
+  providers: [PhraseService],
+  controllers: [PhraseController],
+})
+export class PhraseModule {}

--- a/src/phrase/phrase.service.spec.ts
+++ b/src/phrase/phrase.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PhraseService } from './phrase.service';
+
+describe('PhraseService', () => {
+  let service: PhraseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PhraseService],
+    }).compile();
+
+    service = module.get<PhraseService>(PhraseService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/phrase/phrase.service.ts
+++ b/src/phrase/phrase.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreatePhraseDto } from './dto/create-phrase.dto';
+import { Phrase } from './entity/phrase.entity';
+import { BooksService } from '../books/books.service';
+import { UsersService } from '../users/users.service';
+
+@Injectable()
+export class PhraseService {
+  constructor(
+    @InjectRepository(Phrase)
+    private readonly phraseRepository: Repository<Phrase>,
+    private readonly booksService: BooksService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async create(createPhraseDto: CreatePhraseDto) {
+    const book = await this.booksService.findById(createPhraseDto.bookId);
+    const user = await this.usersService.findById(createPhraseDto.userId);
+
+    const phrase = new Phrase();
+    phrase.content = createPhraseDto.content;
+    (phrase.book = book), (phrase.user = user);
+    return this.phraseRepository.save(phrase);
+  }
+}

--- a/src/users/entity/user.entity.ts
+++ b/src/users/entity/user.entity.ts
@@ -1,4 +1,4 @@
-import { Phrase } from '../../books/entity/phrase.entity';
+import { Phrase } from '../../phrase/entity/phrase.entity';
 import { Curation } from '../../curations/entity/curation.entity';
 import { Column, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -8,5 +8,6 @@ import { UsersService } from './users.service';
   imports: [TypeOrmModule.forFeature([User])],
   providers: [UsersService],
   controllers: [UsersController],
+  exports: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
- Foreign Key로 참고되어있는 테이블 가져올때 JoinColumn을 Entity에 추가해야함
<img width="505" alt="image" src="https://user-images.githubusercontent.com/39396725/220563031-11acbdc8-43a6-4e48-aae2-c6af8b17287f.png">

- PhraseService에서 BookService와 UserService의 함수를 참조하기 위해서는, Module에 import 및 export 추가해야함
<img width="555" alt="image" src="https://user-images.githubusercontent.com/39396725/220562974-83020140-ec7e-4b89-9cd9-d39a4ac1d30d.png">

- Query Builder에서 LeftJoinAndSelect를 이용하여 외래키로 참조되어있는 테이블의 데이터를 query select 결과로 반환할 수 있었다. 
<img width="455" alt="image" src="https://user-images.githubusercontent.com/39396725/220563265-aa8cc659-a584-464a-b959-f41e107781b9.png">


